### PR TITLE
feat: マイページを実装

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,6 @@
+class ProfilesController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+  end
+end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,32 @@
+<div class="flex-grow flex flex-col items-center justify-center py-12">
+  <div class="w-full max-w-2xl mx-auto px-4">
+    <div class="bg-white rounded-[3rem] shadow-sm p-12 border border-purple-100">
+      <div class="flex flex-col items-center gap-8">
+        <!-- Avatar Icon -->
+        <div class="w-24 h-24 rounded-full bg-purple-100 flex items-center justify-center">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-purple-600" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd" />
+          </svg>
+        </div>
+
+        <h1 class="text-4xl font-bold text-gray-800">Myページ</h1>
+
+        <div class="w-full space-y-6">
+          <div class="border-b border-gray-100 pb-4">
+            <p class="text-sm font-medium text-gray-500 mb-1">ユーザー名</p>
+            <p class="text-2xl text-gray-800"><%= current_user.username %></p>
+          </div>
+
+          <div class="border-b border-gray-100 pb-4">
+            <p class="text-sm font-medium text-gray-500 mb-1">メールアドレス</p>
+            <p class="text-2xl text-gray-800"><%= current_user.email %></p>
+          </div>
+        </div>
+
+        <div class="mt-8">
+          <%= link_to "ホームに戻る", root_path, class: "btn btn-outline btn-info px-12" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -20,10 +20,12 @@
   <div class="navbar-end gap-2">
     <% if user_signed_in? %>
       <div class="dropdown dropdown-end">
-        <div tabindex="0" role="button" class="btn btn-ghost btn-circle">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
+        <div tabindex="0" role="button" class="btn btn-ghost flex items-center gap-2 px-4 rounded-full">
+          <span class="text-xs font-bold text-base-content"><%= current_user.username %></span>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
         </div>
         <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
+          <li><%= link_to "マイページ", profile_path %></li>
           <li><%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %></li>
         </ul>
       </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -32,7 +32,7 @@
 
         <!-- Myページ (Bottom right button) -->
         <div>
-          <%= link_to "#", class: "group relative flex items-center justify-center p-6 bg-purple-300 rounded-[2.5rem] shadow-sm hover:shadow-md transition-all duration-300 border border-purple-400 hover:bg-purple-400" do %>
+          <%= link_to profile_path, class: "group relative flex items-center justify-center p-6 bg-purple-300 rounded-[2.5rem] shadow-sm hover:shadow-md transition-all duration-300 border border-purple-400 hover:bg-purple-400" do %>
             <div class="flex items-center gap-4">
               <div class="w-8 h-8 rounded-full border-2 border-gray-600 flex items-center justify-center group-hover:bg-purple-500/20 transition-colors">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-700" viewBox="0 0 20 20" fill="currentColor">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,7 +5,7 @@ ja:
       user: "ユーザー"
     attributes:
       user:
-        name: "ユーザー名"
+        username: "ユーザー名"
         email: "メールアドレス"
         password: "パスワード"
         password_confirmation: "パスワード（確認用）"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,5 @@ Rails.application.routes.draw do
   root 'static_pages#top'
 
   resources :cocktails, only: [:index, :new, :create]
+  resource :profile, only: [:show]
 end


### PR DESCRIPTION
## 概要
- ログイン後のホーム画面のマイページボタンの遷移先を作成
- ヘッダーのアイコンにマイページへの遷移リンクを追加
- ログイン後のヘッダーのユーザーアイコンの左側にユーザー名を表示

## issue番号
#29 